### PR TITLE
Feature/optional pdf fixing

### DIFF
--- a/document_clipper/pdf.py
+++ b/document_clipper/pdf.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
 import re
 import logging
 import imghdr
@@ -67,8 +66,8 @@ class DocumentClipperPdfReader:
         @param text_to_find: the text to lookup in the 'pages' list in Unicode format
         @param start_page: optionally specify the starting position from which the 'pages' list should be iterated over.
         (default=0)
-        @return: a x_pdflist of dictionary items, where each item contains the page index (key 'page_idx') and the XML node
-        of type 'text' that contain the searched text (key 'content'). Empty list if none was found.
+        @return: a x_pdflist of dictionary items, where each item contains the page index (key 'page_idx') and the XML
+        node of type 'text' that contain the searched text (key 'content'). Empty list if none was found.
         """
         looked_up_pages = pages[slice(start_page, None)]  # From some start position to last item (inclusive)
         content = None

--- a/document_clipper/pdf.py
+++ b/document_clipper/pdf.py
@@ -188,12 +188,10 @@ class DocumentClipperPdfWriter:
 
     def fix_pdf(self, in_path):
         """
-        Performs a call to the 'pdftocairo' poppler-utils cli-tool to generate a
-        non-corrupted, well-formatted PDF file in the tmp directory from an input
-        possibly-corrupted PDF file path.
+        Generates a non-corrupted, well-formatted PDF file from an input
+        possibly-corrupted PDF file path, placed at a temporary directory.
         :param in_path: the possibly-corrupted PDF file path.
-        :return: the corrected PDF file path if the 'pdftocairo' command succeeded.
-        Otherwise, return the original input PDF file path.
+        :return: the corrected PDF file path successful. Otherwise, return the original input PDF file path.
         """
         in_filename = os.path.basename(in_path)
 
@@ -213,9 +211,10 @@ class DocumentClipperPdfWriter:
 
     def image_to_pdf(self, img, pdf_path=None, **kwargs):
         """
-        Convert image to pdf.
-        :param img: image file opened by PIL
-        :param pdf_path: path to save pdf
+        Converts an input image file to a PDF file.
+        :param img: image file opened with the PIL library.
+        :param pdf_path: optional parameter indicating file path of the to-be-generated PDF file.
+        A temporary file is created if no value is provided.
         :param kwargs: any parameter accepted by Image.save i.e. quality
         :return:
         """
@@ -239,17 +238,15 @@ class DocumentClipperPdfWriter:
 
     def merge_pdfs(self, final_pdf_path, actions, append_blank_page=True, fix_files=False):
         """
-        Merge pdf files in only one PDF
-        :param final_pdf_path: file path to save pdf
-        :param actions: list of tuples, each tuple containing a PDF file path and the degrees of counterclockwise
+        Generate a single PDF file containing the combined contents of the input PDF files.
+        :param final_pdf_path: file path to save the merged PDF file.
+        :param actions: list of tuples, each tuple containing a PDF file path and the degrees of the counterclockwise
         rotation to perform on the PDF document.
-        :param append_blank_page: append a blank page between documents if True.
-        :param fix_files: attempt to correct all the incoming PDF file paths.
-        :return:
+        :param append_blank_page: optional flag to indicate whether to append a blank page between documents.
+        :param fix_files: optional flat to indicate whether to attempt to correct all the source PDF files.
+        :return: None. Generates a single PDF file with the contents of the input PDF files and
+        removes any temporary files.
         """
-
-        """ Merge all pdf of a folder in one single file '.pdf'. """
-
         output = PdfFileWriter()
 
         docs_to_close = []
@@ -284,7 +281,6 @@ class DocumentClipperPdfWriter:
 
             docs_to_close.append(document_file)
 
-
         self._write_to_pdf(output, final_pdf_path)
 
         self._close_files(docs_to_close)
@@ -296,7 +292,10 @@ class DocumentClipperPdfWriter:
         :param actions: list of tuples, each tuple consisting of a PDF file path, and the amount of clockwise rotation
         to apply to the document.
         :param append_blank_page: append a blank page between documents if True.
-        :return:
+        :param fix_files: optional boolean flag that when set, attempts to fix the input PDF files provided
+        in the 'actions' parameter.
+        :return: None. Creates a PDF file in the specified path and removes the temporary files that were
+        created (if any).
         """
         real_actions = []
         tmp_to_delete_paths = []
@@ -320,8 +319,11 @@ class DocumentClipperPdfWriter:
         """
         Create new pdf from a slice of pages of a PDF
         :param pdf_file_path: path of the source PDF document, from which a new PDF file will be created.
-        :param pages_actions: list of tuples, each tuple containing the page number and the clockwise rotation to
+        :param page_actions: list of tuples, each tuple containing the page number and the clockwise rotation to
         be applied. The page number is non-zero indexed (first is page 1, and so on).
+        :param final_pdf_path: a string containing the file path of the generated PDF file.
+        :param fix_file: an optional boolean flag that when set, attempts to fix the input PDF file,
+        which could be possibly corrupted
         :return: None. Writes the resulting PDF file into the provided path.
         """
         output = PdfFileWriter()

--- a/document_clipper/utils.py
+++ b/document_clipper/utils.py
@@ -101,15 +101,10 @@ class FixPdfCommand(ShellCommand):
         path_to_corrected_pdf = u"/tmp/%s_%s" % (filename_prefix, in_filename)
 
         try:
-            stdout, stderr = super(FixPdfCommand, self).run(['/usr/bin/pdftocairo', '-pdf',
-                                                        input_file_path, path_to_corrected_pdf])
+            super(FixPdfCommand, self).run(['/usr/bin/pdftocairo', '-pdf',
+                                            input_file_path, path_to_corrected_pdf])
         except exceptions.ShellCommandError:
             return input_file_path
-        except Exception, err:
-            print err
         else:
-            if stderr:
-                return input_file_path
-            else:
-                os.remove(input_file_path)
-                return path_to_corrected_pdf
+            os.remove(input_file_path)
+            return path_to_corrected_pdf

--- a/tests/test_document_clipper_pdf.py
+++ b/tests/test_document_clipper_pdf.py
@@ -297,12 +297,9 @@ class TestDocumentClipperPdf(TestCase):
         self.assertIn(source_file_basename, ret_file_path)
         mock_os_remove.assert_called_with(PATH_TO_PDF_FILE)
 
-    @patch('document_clipper.pdf.subprocess')
     @patch('os.remove')
-    def test_fix_pdf_error(self, mock_os_remove, mock_subprocess):
-        mocked_fixer_process = mock_subprocess.Popen.return_value
-        mocked_fixer_process.communicate.return_value = None, mock.ANY
-
-        ret_file_path = self.document_clipper_pdf_writer.fix_pdf(PATH_TO_PDF_FILE)
-        self.assertEqual(ret_file_path, PATH_TO_PDF_FILE)
+    def test_fix_pdf_error(self, mock_os_remove):
+        invalid_path = u'/invalid/dir/file.pdf'
+        ret_file_path = self.document_clipper_pdf_writer.fix_pdf(invalid_path)
+        self.assertEqual(ret_file_path, invalid_path)
         mock_os_remove.assert_not_called()

--- a/tests/test_document_clipper_pdf.py
+++ b/tests/test_document_clipper_pdf.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from unittest import TestCase
-from mock import mock, Mock, patch
+from mock import Mock, patch
 import os
 
 from document_clipper.pdf import DocumentClipperPdfReader, DocumentClipperPdfWriter

--- a/tests/test_document_clipper_pdf.py
+++ b/tests/test_document_clipper_pdf.py
@@ -2,8 +2,9 @@
 # -*- coding: utf-8 -*-
 
 from unittest import TestCase
-from mock import Mock
+from mock import mock, Mock, patch
 import os
+
 from document_clipper.pdf import DocumentClipperPdfReader, DocumentClipperPdfWriter
 from PIL import Image
 
@@ -26,7 +27,6 @@ class TestDocumentClipperPdf(TestCase):
 
     def tearDown(self):
         self.document_clipper_pdf_reader = None
-
 
     def _images_to_text_method_mocked(self):
         method = Mock()
@@ -112,7 +112,8 @@ class TestDocumentClipperPdf(TestCase):
         new_pdf.close()
         os.remove(new_pdf_path)
 
-    def test_horizontal_image_to_vertical_pdf(self):
+    @patch('os.remove')
+    def test_horizontal_image_to_vertical_pdf(self, mock_os_remove):
         actions = [
             (self.pdf_file.name, 0),
             (PATH_TO_HORIZONTAL_JPG_FILE, 90)
@@ -132,8 +133,10 @@ class TestDocumentClipperPdf(TestCase):
         expected_height = 2677.0
         self.assertEqual(image_width, expected_width)
         self.assertEqual(image_height, expected_height)
+        mock_os_remove.assert_called()
 
-    def test_merge_pdfs_without_rotation(self):
+    @patch('os.remove')
+    def test_merge_pdfs_without_rotation(self, mock_os_remove):
         actions = [(self.pdf_file.name, 0), (self.pdf_file.name, 0)]
         self.document_clipper_pdf_writer.merge(PATH_TO_NEW_PDF_FILE, actions)
         new_pdf = open(PATH_TO_NEW_PDF_FILE)
@@ -141,8 +144,21 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 20)
+        mock_os_remove.assert_not_called()
 
-    def test_merge_pdfs_with_rotation(self):
+    @patch('os.remove')
+    def test_merge_pdfs_with_pdf_fixing(self, mock_os_remove):
+        actions = [(self.pdf_file.name, 0), (self.pdf_file.name, 0)]
+        self.document_clipper_pdf_writer.merge(PATH_TO_NEW_PDF_FILE, actions, fix_files=True)
+        new_pdf = open(PATH_TO_NEW_PDF_FILE)
+        new_document_clipper_pdf_reader = DocumentClipperPdfReader(new_pdf)
+        new_document_clipper_pdf_reader.pdf_to_xml()
+        pages = new_document_clipper_pdf_reader.get_pages()
+        self.assertEqual(len(pages), 20)
+        mock_os_remove.assert_called()
+
+    @patch('os.remove')
+    def test_merge_pdfs_with_rotation(self, mock_os_remove):
         actions = [(self.pdf_file.name, 90), (self.pdf_file.name, 90)]
         self.document_clipper_pdf_writer.merge(PATH_TO_NEW_PDF_FILE, actions)
         new_pdf = open(PATH_TO_NEW_PDF_FILE)
@@ -150,8 +166,10 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 20)
+        mock_os_remove.assert_not_called()
 
-    def test_merge_pdfs_with_blank_page(self):
+    @patch('os.remove')
+    def test_merge_pdfs_with_blank_page(self, mock_os_remove):
         actions = [(self.pdf_file.name, 0), (self.pdf_file.name, 0)]
         self.document_clipper_pdf_writer.merge(PATH_TO_NEW_PDF_FILE, actions,
                                                append_blank_page=True)
@@ -160,8 +178,10 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 22)
+        mock_os_remove.assert_not_called()
 
-    def test_merge_files_without_rotation(self):
+    @patch('os.remove')
+    def test_merge_files_without_rotation(self, mock_os_remove):
         actions = [(self.pdf_file.name, 0), (PATH_TO_JPG_FILE, 0)]
         self.document_clipper_pdf_writer.merge(PATH_TO_NEW_PDF_FILE, actions)
         new_pdf = open(PATH_TO_NEW_PDF_FILE)
@@ -169,8 +189,10 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 11)
+        mock_os_remove.assert_called()
 
-    def test_merge_files_with_rotation(self):
+    @patch('os.remove')
+    def test_merge_files_with_rotation(self, mock_os_remove):
         actions = [(self.pdf_file.name, 0), (PATH_TO_JPG_FILE, 90)]
         self.document_clipper_pdf_writer.merge(PATH_TO_NEW_PDF_FILE, actions)
         new_pdf = open(PATH_TO_NEW_PDF_FILE)
@@ -178,8 +200,10 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 11)
+        mock_os_remove.assert_called()
 
-    def test_merge_files_with_blank_page(self):
+    @patch('os.remove')
+    def test_merge_files_with_blank_page(self, mock_os_remove):
         actions = [(self.pdf_file.name, 0), (PATH_TO_JPG_FILE, 0)]
         self.document_clipper_pdf_writer.merge(PATH_TO_NEW_PDF_FILE, actions,
                                                append_blank_page=True)
@@ -188,8 +212,10 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 13)
+        mock_os_remove.assert_called()
 
-    def test_slice(self):
+    @patch('os.remove')
+    def test_slice(self, mock_os_remove):
         page_actions = [(2, 0), (3, 0)]
         self.document_clipper_pdf_writer.slice(self.pdf_file.name, page_actions, PATH_TO_NEW_PDF_FILE)
 
@@ -198,21 +224,40 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 2)
+        mock_os_remove.assert_not_called()
 
-    def test_slice_with_page_candidate_below_valid_page_range(self):
+    @patch('os.remove')
+    def test_slice_with_pdf_fixing(self, mock_os_remove):
+        page_actions = [(2, 0), (3, 0)]
+        self.document_clipper_pdf_writer.slice(self.pdf_file.name, page_actions, PATH_TO_NEW_PDF_FILE, fix_file=True)
+
+        new_pdf = open(PATH_TO_NEW_PDF_FILE)
+        new_document_clipper_pdf_reader = DocumentClipperPdfReader(new_pdf)
+        new_document_clipper_pdf_reader.pdf_to_xml()
+        pages = new_document_clipper_pdf_reader.get_pages()
+        self.assertEqual(len(pages), 2)
+        mock_os_remove.assert_called()
+
+    @patch('os.remove')
+    def test_slice_with_page_candidate_below_valid_page_range(self, mock_os_remove):
         page_actions = [(0, 0), (3, 0)]
 
         with self.assertRaisesRegexp(Exception, u'Invalid page numbers range in actions: '
                                                 u'page numbers cannot be lower than 1*'):
             self.document_clipper_pdf_writer.slice(self.pdf_file.name, page_actions, PATH_TO_NEW_PDF_FILE)
+            mock_os_remove.assert_called()
 
-    def test_slice_with_page_candidate_above_valid_page_range(self):
+    @patch('os.remove')
+    def test_slice_with_page_candidate_above_valid_page_range(self, mock_os_remove):
         page_actions = [(50, 0), (3, 0)]
 
         with self.assertRaisesRegexp(Exception, u'Invalid page numbers range in actions: page numbers cannot exceed*'):
             self.document_clipper_pdf_writer.slice(self.pdf_file.name, page_actions, PATH_TO_NEW_PDF_FILE)
 
-    def test_slice_with_rotation(self):
+            mock_os_remove.assert_not_called()
+
+    @patch('os.remove')
+    def test_slice_with_rotation(self, mock_os_remove):
         self.document_clipper_pdf_writer.slice(self.pdf_file.name, [(2, 90), (4, 180)], PATH_TO_NEW_PDF_FILE)
 
         new_pdf = open(PATH_TO_NEW_PDF_FILE)
@@ -220,6 +265,7 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 2)
+        mock_os_remove.assert_not_called()
 
     def test_pdf_to_text_from_pdf_with_only_text(self):
         text = self.document_clipper_pdf_reader.pdf_to_text()
@@ -242,3 +288,21 @@ class TestDocumentClipperPdf(TestCase):
         self.document_clipper_pdf_reader = DocumentClipperPdfReader(self.pdf_file)
         self.document_clipper_pdf_reader.pdf_to_text(self._images_to_text_method_mocked())
         self.assertEqual(1, len(self.document_clipper_pdf_reader._pdf_image_to_text_method.call_args_list))
+
+    @patch('os.remove')
+    def test_fix_pdf_ok(self, mock_os_remove):
+        ret_file_path = self.document_clipper_pdf_writer.fix_pdf(PATH_TO_PDF_FILE)
+        source_file_basename = os.path.basename(PATH_TO_PDF_FILE)
+        self.assertNotEqual(ret_file_path, PATH_TO_PDF_FILE)
+        self.assertIn(source_file_basename, ret_file_path)
+        mock_os_remove.assert_called_with(PATH_TO_PDF_FILE)
+
+    @patch('document_clipper.pdf.subprocess')
+    @patch('os.remove')
+    def test_fix_pdf_error(self, mock_os_remove, mock_subprocess):
+        mocked_fixer_process = mock_subprocess.Popen.return_value
+        mocked_fixer_process.communicate.return_value = None, mock.ANY
+
+        ret_file_path = self.document_clipper_pdf_writer.fix_pdf(PATH_TO_PDF_FILE)
+        self.assertEqual(ret_file_path, PATH_TO_PDF_FILE)
+        mock_os_remove.assert_not_called()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@
 from unittest import TestCase
 import os
 import shutil
-from mock import mock, patch
+from mock import patch
 from document_clipper.utils import PDFToTextCommand, PDFToImagesCommand, PDFListImagesCommand, FixPdfCommand
 from document_clipper.exceptions import ShellCommandError
 from PIL import Image

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,9 +92,8 @@ class TestShellCommands(TestCase):
         self.assertNotEqual(ret_file_path, PATH_TO_PDF_FILE)
         mock_os_remove.assert_called_with(PATH_TO_PDF_FILE)
 
-    @patch('document_clipper.utils.ShellCommand')
     @patch('os.remove')
-    def test_fix_pdf_command_error(self, mock_os_remove, mock_shell_command):
+    def test_fix_pdf_command_exception(self, mock_os_remove):
         invalid_file_path = u'/tmp/bla/file.pdf'
         fix_pdf_commmand = FixPdfCommand()
         ret_file_path = fix_pdf_commmand.run(invalid_file_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,8 @@
 from unittest import TestCase
 import os
 import shutil
-from document_clipper.utils import PDFToTextCommand, PDFToImagesCommand, PDFListImagesCommand
+from mock import mock, patch
+from document_clipper.utils import PDFToTextCommand, PDFToImagesCommand, PDFListImagesCommand, FixPdfCommand
 from document_clipper.exceptions import ShellCommandError
 from PIL import Image
 
@@ -83,3 +84,19 @@ class TestShellCommands(TestCase):
         pdftoimages_cmd = PDFToImagesCommand()
         out = pdftoimages_cmd.run(PATH_TO_PDF_FILE_WITH_IMAGES_NO_JPG, 1)
         self.assertEqual(1, len(os.listdir(out)))
+
+    @patch('os.remove')
+    def test_fix_pdf_command_ok(self, mock_os_remove):
+        fix_pdf_command = FixPdfCommand()
+        ret_file_path = fix_pdf_command.run(PATH_TO_PDF_FILE)
+        self.assertNotEqual(ret_file_path, PATH_TO_PDF_FILE)
+        mock_os_remove.assert_called_with(PATH_TO_PDF_FILE)
+
+    @patch('document_clipper.utils.ShellCommand')
+    @patch('os.remove')
+    def test_fix_pdf_command_error(self, mock_os_remove, mock_shell_command):
+        invalid_file_path = u'/tmp/bla/file.pdf'
+        fix_pdf_commmand = FixPdfCommand()
+        ret_file_path = fix_pdf_commmand.run(invalid_file_path)
+        self.assertEqual(ret_file_path, invalid_file_path)
+        mock_os_remove.assert_not_called()


### PR DESCRIPTION
Taking advantage of the `poppler-utils` tools, **document-clipper** can benefit from the `pdftocairo` CLI-tool to generate new well-formatted, non-corrupted PDF files before attempting merge/slice actions on one or more input PDF files.