### PR TITLE
When attempting to delete the temporary pdf-image files created durin…

### DIFF
--- a/document_clipper/pdf.py
+++ b/document_clipper/pdf.py
@@ -296,7 +296,13 @@ class DocumentClipperPdfWriter:
         self.merge_pdfs(final_pdf_path, real_actions, append_blank_page, fix_files)
 
         for path_to_delete in tmp_to_delete_paths:
-            os.remove(path_to_delete)
+            # Tmp files to be deleted may already have been deleted due to a pdf fixing process (which already
+            # deletes the bad-formatted PDF file). Skip the triggered exception, since file could be already deleted.
+            try:
+                os.remove(path_to_delete)
+            except OSError:
+                logging.warning("Cannot delete file with file path %s. It seems it was already deleted."
+                                % path_to_delete)
 
     def slice(self, pdf_file_path, page_actions, final_pdf_path, fix_file=False):
         """

--- a/tests/test_document_clipper_pdf.py
+++ b/tests/test_document_clipper_pdf.py
@@ -202,6 +202,23 @@ class TestDocumentClipperPdf(TestCase):
         self.assertEqual(len(pages), 11)
         mock_os_remove.assert_called()
 
+    @patch('document_clipper.pdf.logging')
+    @patch('os.remove')
+    def test_merge_images_with_pdf_fixing(self, mock_os_remove, mock_logging):
+        # Setup
+        mock_os_remove.side_effect = [None, None, OSError('already deleted'), OSError('already deleted')]
+        actions = [(PATH_TO_HORIZONTAL_JPG_FILE, 0), (PATH_TO_JPG_FILE, 90)]
+        self.document_clipper_pdf_writer.merge(PATH_TO_NEW_PDF_FILE, actions, fix_files=True)
+        new_pdf = open(PATH_TO_NEW_PDF_FILE)
+        new_document_clipper_pdf_reader = DocumentClipperPdfReader(new_pdf)
+        new_document_clipper_pdf_reader.pdf_to_xml()
+        pages = new_document_clipper_pdf_reader.get_pages()
+        self.assertEqual(len(pages), 2)
+        num_os_remove_calls = len(mock_os_remove.call_args_list[0])
+        self.assertEqual(num_os_remove_calls, 2)
+        num_logging_calls = len(mock_logging.warning.call_args_list[0])
+        self.assertEqual(num_logging_calls, 2)
+
     @patch('os.remove')
     def test_merge_files_with_blank_page(self, mock_os_remove):
         actions = [(self.pdf_file.name, 0), (PATH_TO_JPG_FILE, 0)]


### PR DESCRIPTION
…g the merge process, skip the OSError exception triggered during the following case: when merging AND fixing PDF files, the original PDF file paths are removed by the fixer method. When attempting to delete such files at the end of the merging process, an OSErro exception would be raised. Since the file-to-be-deleted was already deleted, there is no need to panic, so the Exception can output a logging message and continue.