### PR TITLE
fix before merging but only to pdf files

### DIFF
--- a/document_clipper/pdf.py
+++ b/document_clipper/pdf.py
@@ -245,14 +245,13 @@ class DocumentClipperPdfWriter(BaseDocumentClipperPdf):
         tmp_image.save(pdf_path, "PDF", resolution=100.0, **kwargs)
         return pdf_path
 
-    def merge_pdfs(self, final_pdf_path, actions, append_blank_page=True, fix_files=False):
+    def merge_pdfs(self, final_pdf_path, actions, append_blank_page=True):
         """
         Generate a single PDF file containing the combined contents of the input PDF files.
         :param final_pdf_path: file path to save the merged PDF file.
         :param actions: list of tuples, each tuple containing a PDF file path and the degrees of the counterclockwise
         rotation to perform on the PDF document.
         :param append_blank_page: optional flag to indicate whether to append a blank page between documents.
-        :param fix_files: optional flat to indicate whether to attempt to correct all the source PDF files.
         :return: None. Generates a single PDF file with the contents of the input PDF files and
         removes any temporary files.
         """
@@ -270,10 +269,7 @@ class DocumentClipperPdfWriter(BaseDocumentClipperPdf):
             logging.info(u"Parse '%s'" % pdf_file_path)
 
             try:
-                path_to_file = pdf_file_path
-                if fix_files:
-                    path_to_file = self.fix_pdf(pdf_file_path)
-                document_file = open(path_to_file, 'rb')
+                document_file = open(pdf_file_path, 'rb')
                 document = PdfFileReader(document_file, strict=False)
                 num_pages = document.getNumPages()
             except Exception as exc:
@@ -316,10 +312,12 @@ class DocumentClipperPdfWriter(BaseDocumentClipperPdf):
                 real_actions.append(action)
                 tmp_to_delete_paths.append(path)
             else:
+                if fix_files:
+                    file_path = self.fix_pdf(file_path)
                 action = (file_path, rotation)
                 real_actions.append(action)
 
-        self.merge_pdfs(final_pdf_path, real_actions, append_blank_page, fix_files)
+        self.merge_pdfs(final_pdf_path, real_actions, append_blank_page)
 
         for path_to_delete in tmp_to_delete_paths:
             # Tmp files to be deleted may already have been deleted due to a pdf fixing process (which already

--- a/tests/test_document_clipper_pdf.py
+++ b/tests/test_document_clipper_pdf.py
@@ -210,9 +210,8 @@ class TestDocumentClipperPdf(TestCase):
         self.assertEqual(len(pages), 11)
         mock_os_remove.assert_called()
 
-    @patch('document_clipper.pdf.logging')
     @patch('os.remove')
-    def test_merge_images_with_pdf_fixing(self, mock_os_remove, mock_logging):
+    def test_merge_images_with_pdf_fixing(self, mock_os_remove):
         # Setup
         mock_os_remove.side_effect = [None, None, OSError('already deleted'), OSError('already deleted')]
         actions = [(PATH_TO_HORIZONTAL_JPG_FILE, 0), (PATH_TO_JPG_FILE, 90)]
@@ -224,8 +223,6 @@ class TestDocumentClipperPdf(TestCase):
         self.assertEqual(len(pages), 2)
         num_os_remove_calls = len(mock_os_remove.call_args_list[0])
         self.assertEqual(num_os_remove_calls, 2)
-        num_logging_calls = len(mock_logging.warning.call_args_list[0])
-        self.assertEqual(num_logging_calls, 2)
 
     @patch('os.remove')
     def test_merge_files_with_blank_page(self, mock_os_remove):

--- a/tests/test_document_clipper_pdf.py
+++ b/tests/test_document_clipper_pdf.py
@@ -225,6 +225,20 @@ class TestDocumentClipperPdf(TestCase):
         self.assertEqual(num_os_remove_calls, 2)
 
     @patch('os.remove')
+    def test_merge_images_and_pdfs_with_pdf_fixing(self, mock_os_remove):
+        # Setup
+        mock_os_remove.side_effect = [None, None, OSError('already deleted'), OSError('already deleted')]
+        actions = [(self.pdf_file.name, 0), (PATH_TO_JPG_FILE, 90)]
+        self.document_clipper_pdf_writer.merge(PATH_TO_NEW_PDF_FILE, actions, fix_files=True)
+        new_pdf = open(PATH_TO_NEW_PDF_FILE)
+        new_document_clipper_pdf_reader = DocumentClipperPdfReader(new_pdf)
+        new_document_clipper_pdf_reader.pdf_to_xml()
+        pages = new_document_clipper_pdf_reader.get_pages()
+        self.assertEqual(len(pages), 11)
+        num_os_remove_calls = len(mock_os_remove.call_args_list[0])
+        self.assertEqual(num_os_remove_calls, 2)
+
+    @patch('os.remove')
     def test_merge_files_with_blank_page(self, mock_os_remove):
         actions = [(self.pdf_file.name, 0), (PATH_TO_JPG_FILE, 0)]
         self.document_clipper_pdf_writer.merge(PATH_TO_NEW_PDF_FILE, actions,


### PR DESCRIPTION
Fix only pdfs when merging not the pdfs generated from images. 
pdftocairo older versions 0.18.4 may fail