### PR TITLE
Added two more test cases related to exception handlint to `FixPdfCom…

### DIFF
--- a/document_clipper/utils.py
+++ b/document_clipper/utils.py
@@ -35,7 +35,7 @@ class ShellCommand(object):
                     ' '.join(args), 127, '', '',
                 )
             else:
-                raise exceptions.ShellCommandError(' '.join(args), e.errno or -1 , '', e.strerror or '')
+                raise exceptions.ShellCommandError(' '.join(args), e.errno or -1, '', e.strerror or '')
 
         # pipe.wait() ends up hanging on large files. using
         # pipe.communicate appears to avoid this issue

--- a/document_clipper/utils.py
+++ b/document_clipper/utils.py
@@ -34,6 +34,8 @@ class ShellCommand(object):
                 raise exceptions.ShellCommandError(
                     ' '.join(args), 127, '', '',
                 )
+            else:
+                raise exceptions.ShellCommandError(' '.join(args), e.errno or -1 , '', e.strerror or '')
 
         # pipe.wait() ends up hanging on large files. using
         # pipe.communicate appears to avoid this issue
@@ -104,6 +106,8 @@ class FixPdfCommand(ShellCommand):
             super(FixPdfCommand, self).run(['/usr/bin/pdftocairo', '-pdf',
                                             input_file_path, path_to_corrected_pdf])
         except exceptions.ShellCommandError:
+            return input_file_path
+        except Exception:
             return input_file_path
         else:
             os.remove(input_file_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,7 +95,28 @@ class TestShellCommands(TestCase):
     @patch('os.remove')
     def test_fix_pdf_command_exception(self, mock_os_remove):
         invalid_file_path = u'/tmp/bla/file.pdf'
-        fix_pdf_commmand = FixPdfCommand()
-        ret_file_path = fix_pdf_commmand.run(invalid_file_path)
+        fix_pdf_command = FixPdfCommand()
+        ret_file_path = fix_pdf_command.run(invalid_file_path)
         self.assertEqual(ret_file_path, invalid_file_path)
+        mock_os_remove.assert_not_called()
+
+    @patch('os.remove')
+    @patch('document_clipper.utils.subprocess.Popen')
+    def test_fix_pdf_command_os_error_exception(self, mock_open, mock_os_remove):
+        mocked_exception = OSError('Random os error')
+        mocked_exception.errno = None
+
+        fix_pdf_command = FixPdfCommand()
+        ret_file_path = fix_pdf_command.run(PATH_TO_PDF_FILE)
+        self.assertEqual(ret_file_path, PATH_TO_PDF_FILE)
+        mock_os_remove.assert_not_called()
+
+    @patch('os.remove')
+    @patch('document_clipper.utils.subprocess.Popen')
+    def test_fix_pdf_command_generic_exception(self, mock_popen, mock_os_remove):
+        mocked_exception = Exception('blabla')
+        mock_popen.side_effect = mocked_exception
+        fix_pdf_command = FixPdfCommand()
+        ret_file_path = fix_pdf_command.run(PATH_TO_PDF_FILE)
+        self.assertEqual(ret_file_path, PATH_TO_PDF_FILE)
         mock_os_remove.assert_not_called()


### PR DESCRIPTION
…mand`. Also raise `ShellCommandException` error always when an `OSError` occurs.