### PR TITLE
Only local images were deleted after merging documents into a single …

### DIFF
--- a/document_clipper/pdf.py
+++ b/document_clipper/pdf.py
@@ -321,6 +321,7 @@ class DocumentClipperPdfWriter(BaseDocumentClipperPdf):
                     file_path = self.fix_pdf(file_path)
                 action = (file_path, rotation)
                 real_actions.append(action)
+                tmp_to_delete_paths.append(file_path)
 
         self.merge_pdfs(final_pdf_path, real_actions, append_blank_page)
 

--- a/tests/test_document_clipper_pdf.py
+++ b/tests/test_document_clipper_pdf.py
@@ -157,7 +157,7 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 20)
-        mock_os_remove.assert_not_called()
+        self.assertEqual(len(mock_os_remove.call_args_list), 2)
 
     @patch('os.remove')
     def test_merge_pdfs_with_pdf_fixing(self, mock_os_remove):
@@ -179,7 +179,7 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 20)
-        mock_os_remove.assert_not_called()
+        self.assertEqual(len(mock_os_remove.call_args_list), 2)
 
     @patch('os.remove')
     def test_merge_pdfs_with_blank_page(self, mock_os_remove):
@@ -191,7 +191,7 @@ class TestDocumentClipperPdf(TestCase):
         new_document_clipper_pdf_reader.pdf_to_xml()
         pages = new_document_clipper_pdf_reader.get_pages()
         self.assertEqual(len(pages), 22)
-        mock_os_remove.assert_not_called()
+        self.assertEqual(len(mock_os_remove.call_args_list), 2)
 
     @patch('os.remove')
     def test_merge_files_without_rotation(self, mock_os_remove):


### PR DESCRIPTION
…PDF. Now both image and non-image files are deleted at the end of the merging process, saving storage space after merging.