### PR TITLE
ci.travis: remove not needed travis installation for headless testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ python:
 - 3.4
 - 3.5
 before_install:
-    - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
-    - sleep 3 # give xvfb some time to start
     - sudo apt-get -qq update
     - sudo apt-get install poppler-utils
     - pip install coveralls


### PR DESCRIPTION
Remove travis headless failed configuration not needed in the tests. 